### PR TITLE
fix: Use git dep for iroh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,8 +700,8 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-future",
  "rand 0.8.5",
  "tokio",
@@ -716,8 +716,8 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-future",
  "rand 0.8.5",
  "tokio",
@@ -732,8 +732,8 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (git+https://github.com/n0-computer/iroh)",
+ "iroh-base 0.90.0 (git+https://github.com/n0-computer/iroh)",
  "n0-future",
  "rand 0.8.5",
  "tokio",
@@ -1361,7 +1361,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1565,7 +1565,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1609,21 +1609,21 @@ dependencies = [
  "http 1.3.1",
  "igd-next",
  "instant",
- "iroh-base",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-metrics",
  "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
- "iroh-relay",
+ "iroh-relay 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-future",
  "n0-snafu",
  "n0-watcher",
  "nested_enum_utils",
- "netdev",
- "netwatch",
+ "netdev 0.31.0",
+ "netwatch 0.6.0",
  "pin-project",
  "pkarr",
- "portmapper",
+ "portmapper 0.6.1",
  "rand 0.8.5",
  "reqwest",
  "ring",
@@ -1634,7 +1634,67 @@ dependencies = [
  "smallvec",
  "snafu",
  "spki",
- "strum",
+ "strum 0.26.3",
+ "stun-rs",
+ "surge-ping",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "webpki-roots 0.26.11",
+ "z32",
+]
+
+[[package]]
+name = "iroh"
+version = "0.90.0"
+source = "git+https://github.com/n0-computer/iroh#e2cfde779cf3d04b15aafe5d193c171454463220"
+dependencies = [
+ "aead",
+ "backon",
+ "bytes",
+ "cfg_aliases",
+ "crypto_box",
+ "data-encoding",
+ "der",
+ "derive_more 2.0.1",
+ "ed25519-dalek",
+ "futures-buffered",
+ "futures-util",
+ "getrandom 0.3.3",
+ "hickory-resolver",
+ "http 1.3.1",
+ "igd-next",
+ "instant",
+ "iroh-base 0.90.0 (git+https://github.com/n0-computer/iroh)",
+ "iroh-metrics",
+ "iroh-quinn",
+ "iroh-quinn-proto",
+ "iroh-quinn-udp",
+ "iroh-relay 0.90.0 (git+https://github.com/n0-computer/iroh)",
+ "n0-future",
+ "n0-snafu",
+ "n0-watcher",
+ "nested_enum_utils",
+ "netdev 0.36.0",
+ "netwatch 0.7.0",
+ "pin-project",
+ "pkarr",
+ "portmapper 0.7.0",
+ "rand 0.8.5",
+ "reqwest",
+ "ring",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "smallvec",
+ "snafu",
+ "spki",
+ "strum 0.27.2",
  "stun-rs",
  "surge-ping",
  "time",
@@ -1668,6 +1728,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-base"
+version = "0.90.0"
+source = "git+https://github.com/n0-computer/iroh#e2cfde779cf3d04b15aafe5d193c171454463220"
+dependencies = [
+ "curve25519-dalek",
+ "data-encoding",
+ "derive_more 2.0.1",
+ "ed25519-dalek",
+ "n0-snafu",
+ "nested_enum_utils",
+ "postcard",
+ "rand_core 0.6.4",
+ "serde",
+ "snafu",
+ "url",
+]
+
+[[package]]
 name = "iroh-blobs"
 version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,8 +1761,8 @@ dependencies = [
  "futures-lite",
  "genawaiter",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-io",
  "iroh-metrics",
  "iroh-quinn",
@@ -1718,8 +1796,8 @@ dependencies = [
  "ed25519-dalek",
  "futures-buffered",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-blobs",
  "n0-future",
  "postcard",
@@ -1783,7 +1861,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -1820,7 +1898,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1841,7 +1919,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-base",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-metrics",
  "iroh-quinn",
  "iroh-quinn-proto",
@@ -1861,11 +1939,60 @@ dependencies = [
  "serde",
  "sha1",
  "snafu",
- "strum",
+ "strum 0.26.3",
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tokio-websockets",
+ "tokio-websockets 0.11.4",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+ "ws_stream_wasm",
+ "z32",
+]
+
+[[package]]
+name = "iroh-relay"
+version = "0.90.0"
+source = "git+https://github.com/n0-computer/iroh#e2cfde779cf3d04b15aafe5d193c171454463220"
+dependencies = [
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "data-encoding",
+ "derive_more 2.0.1",
+ "getrandom 0.3.3",
+ "hickory-resolver",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "iroh-base 0.90.0 (git+https://github.com/n0-computer/iroh)",
+ "iroh-metrics",
+ "iroh-quinn",
+ "iroh-quinn-proto",
+ "lru",
+ "n0-future",
+ "n0-snafu",
+ "nested_enum_utils",
+ "num_enum",
+ "pin-project",
+ "pkarr",
+ "postcard",
+ "rand 0.8.5",
+ "reqwest",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "serde_bytes",
+ "sha1",
+ "snafu",
+ "strum 0.27.2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets 0.12.0",
  "tracing",
  "url",
  "webpki-roots 0.26.11",
@@ -2176,6 +2303,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "netdev"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862209dce034f82a44c95ce2b5183730d616f2a68746b9c1959aa2572e77c0a1"
+dependencies = [
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-route 0.22.0",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,9 +2346,39 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.1",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0800eae8638a299eaa67476e1c6b6692922273e0f7939fd188fc861c837b9cd2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.1",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d83370a96813d7c977f8b63054f1162df6e5784f1c598d689236564fb5a6f2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -2270,7 +2444,7 @@ dependencies = [
  "n0-future",
  "n0-watcher",
  "nested_enum_utils",
- "netdev",
+ "netdev 0.31.0",
  "netlink-packet-core",
  "netlink-packet-route 0.23.0",
  "netlink-proto",
@@ -2278,7 +2452,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "snafu",
- "socket2",
+ "socket2 0.5.10",
  "time",
  "tokio",
  "tokio-util",
@@ -2286,7 +2460,42 @@ dependencies = [
  "web-sys",
  "windows 0.59.0",
  "windows-result",
- "wmi",
+ "wmi 0.14.5",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0445cbbb4d6d1afe22f4d1c14da2a2eb598a98b83650f15f988050bceefea5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more 2.0.1",
+ "iroh-quinn-udp",
+ "js-sys",
+ "libc",
+ "n0-future",
+ "n0-watcher",
+ "nested_enum_utils",
+ "netdev 0.36.0",
+ "netlink-packet-core",
+ "netlink-packet-route 0.24.0",
+ "netlink-proto",
+ "netlink-sys",
+ "pin-project-lite",
+ "serde",
+ "snafu",
+ "socket2 0.6.0",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.61.3",
+ "windows-result",
+ "wmi 0.17.2",
 ]
 
 [[package]]
@@ -2666,13 +2875,44 @@ dependencies = [
  "iroh-metrics",
  "libc",
  "nested_enum_utils",
- "netwatch",
+ "netwatch 0.6.0",
  "num_enum",
  "rand 0.8.5",
  "serde",
  "smallvec",
  "snafu",
- "socket2",
+ "socket2 0.5.10",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "portmapper"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abceb40595a7a1b65242013b497d031000c1c0e58505d4c5f7834951fd3800d4"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "derive_more 2.0.1",
+ "futures-lite",
+ "futures-util",
+ "hyper-util",
+ "igd-next",
+ "iroh-metrics",
+ "libc",
+ "nested_enum_utils",
+ "netwatch 0.7.0",
+ "num_enum",
+ "rand 0.9.1",
+ "serde",
+ "smallvec",
+ "snafu",
+ "socket2 0.6.0",
  "time",
  "tokio",
  "tokio-util",
@@ -2837,7 +3077,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2874,7 +3114,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3358,8 +3598,8 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-blobs",
  "n0-future",
  "rand 0.8.5",
@@ -3376,8 +3616,8 @@ dependencies = [
  "base64 0.21.7",
  "futures",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-blobs",
  "num_cpus",
  "rand 0.8.5",
@@ -3395,8 +3635,8 @@ dependencies = [
  "base64 0.21.7",
  "futures",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-blobs",
  "num_cpus",
  "rand 0.8.5",
@@ -3414,8 +3654,8 @@ dependencies = [
  "base64 0.21.7",
  "futures",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iroh-base 0.90.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-blobs",
  "iroh-content-discovery",
  "num_cpus",
@@ -3632,6 +3872,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,7 +3912,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -3675,6 +3934,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.103",
 ]
 
@@ -3718,7 +3989,7 @@ dependencies = [
  "parking_lot",
  "pnet_packet",
  "rand 0.9.1",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3920,7 +4191,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -3980,6 +4251,28 @@ name = "tokio-websockets"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fcaf159b4e7a376b05b5bfd77bfd38f3324f5fce751b4213bfc7eaa47affb4e"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "getrandom 0.3.3",
+ "http 1.3.1",
+ "httparse",
+ "rand 0.9.1",
+ "ring",
+ "rustls-pki-types",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f29ba084eb43becc9864ba514b4a64f5f65b82f9a6ffbafa5436c1c80605f03"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4920,6 +5213,21 @@ dependencies = [
  "thiserror 2.0.12",
  "windows 0.59.0",
  "windows-core 0.59.0",
+]
+
+[[package]]
+name = "wmi"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3de777dce4cbcdc661d5d18e78ce4b46a37adc2bb7c0078a556c7f07bcce2f"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 2.0.12",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ members = [
 
 # Optional: Add a resolver to ensure consistent dependency versions
 [workspace.dependencies]
-iroh = "0.35"
-iroh-base = "0.35"
+iroh = "0.90"
+iroh-base = "0.90"
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"
 tracing = "0.1"

--- a/echo3/Cargo.toml
+++ b/echo3/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-iroh = { version = "0.90", features = ["metrics", "discovery-pkarr-dht"] }
-iroh-base = "0.90"
+iroh = { version = "0.90", features = ["metrics", "discovery-pkarr-dht"], git = "https://github.com/n0-computer/iroh" }
+iroh-base = { version = "0.90", git = "https://github.com/n0-computer/iroh" }
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"
 tracing = "0.1"


### PR DESCRIPTION
the released version of iroh contains a bug regarding dht record publishing, which is fixed on main.

Todo: point to released iroh when we release new iroh.